### PR TITLE
Update AWS provider for terraform >= `v0.13`

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,19 @@ The static website is published on a subdomain registered in Route 53.
 > A live example can be found at [https://serverless-static-website-with-basic-auth.dumrauf.uk/](https://serverless-static-website-with-basic-auth.dumrauf.uk/?utm_source=GitHub&utm_medium=social&utm_campaign=README) using the demo username `guest` and password [`letmein`](https://www.theguardian.com/technology/2016/jan/20/123456-worst-passwords-revealed).
 > Note that access to the underlying [S3 bucket](https://us-east-1-serverless-webs-serverlesswebsitebucket-1mtsv4odbs2x0.s3.amazonaws.com) hosting the static website is denied.
 
-The master branch in this repository is compliant with [Terraform v0.12](https://www.terraform.io/upgrade-guides/0-12.html); a legacy version that is compatible with [Terraform v0.11](https://www.terraform.io/upgrade-guides/0-11.html) is available on branch [terraform@0.11](https://github.com/dumrauf/serverless_static_website_with_basic_auth/tree/terraform%400.11).
+The master branch in this repository is compliant with [Terraform >= v0.13](https://www.terraform.io/language/v1.1.x/upgrade-guides/0-13); a legacy version that is compatible with [Terraform v0.11](https://www.terraform.io/upgrade-guides/0-11.html) is available on branch [terraform@0.11](https://github.com/dumrauf/serverless_static_website_with_basic_auth/tree/terraform%400.11).
+
+> **Note**
+> Upgrading from `v0.12` to later versions
+
+Due to changes in the AWS provider, if you have existing state from <= `v0.12` and are upgrading to >= `v0.13` the following will achieve that:
+
+```shell
+terraform state replace-provider -- -/random hashicorp/random
+terraform state replace-provider -- -/archive hashicorp/archive
+terraform state replace-provider -- -/aws hashicorp/aws
+terraform init
+```
 
 ## You Have
 

--- a/Terraform/providers.tf
+++ b/Terraform/providers.tf
@@ -1,6 +1,13 @@
-provider "aws" {
-  region                  = var.region
-  shared_credentials_file = var.shared_credentials_file
-  profile                 = var.profile
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.0"
+    }
+  }
 }
-
+provider "aws" {
+  region                   = var.region
+  shared_credentials_files = [var.shared_credentials_file]
+  profile                  = var.profile
+}


### PR DESCRIPTION
Change:

- terraform 0.13 and onwards requires new providers declaration
- `shared_credentials_file` is deprecated

Required commands to upgrade existing state from `v0.12` to >= `v0.13`, tested with `v1.2.9`:

```shell
terraform state replace-provider -- -/random hashicorp/random
terraform state replace-provider -- -/archive hashicorp/archive
terraform state replace-provider -- -/aws hashicorp/aws
terraform init
```

A `terraform version` command then shows:

```shell
Terraform v1.2.9
on darwin_amd64
+ provider registry.terraform.io/hashicorp/archive v2.2.0
+ provider registry.terraform.io/hashicorp/aws v4.31.0
+ provider registry.terraform.io/hashicorp/random v3.4.3
```

There are a bunch of other AWS deprecated items, but I'll pop them in another PR after this to keep it cleaner.